### PR TITLE
Offline transaction creation

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,10 +1,12 @@
 {
-	"apiEndpoint": "https://testnet-service.lisk.io/api/v2/",
-	"interactive": true,
-	"delegateName": "dakk",
-	"sharingPercentage": 15,
-	"minPayout": 0.0,
-	"blackList": [],
-	"poolState": "poollogs.json",
-	"paymentsFile": "payments.sh"
+  "apiEndpoint": "https://testnet-service.lisk.io/api/v2/",
+  "network": "testnet",
+  "networkIdentifier": "15f0dacc1060e91818224a94286b13aa04279c640bd5d6f193182031d133df7c",
+  "interactive": true,
+  "delegateName": "dakk",
+  "sharingPercentage": 15,
+  "minPayout": 0.0,
+  "blackList": [],
+  "poolState": "poollogs.json",
+  "paymentsFile": "payments.sh"
 }

--- a/liskpool3.py
+++ b/liskpool3.py
@@ -215,8 +215,8 @@ def savePayments(conf, topay):
 
 	st = ['echo Write passphrase: ', 'read PASSPHRASE']
 	for x in topay:
-		nonce += 1
 		st.append(paymentCommandForLiskCore(conf, x[0], x[1], nonce))
+		nonce += 1
 
 	s = '\n'.join(st)
 	

--- a/liskpool3.py
+++ b/liskpool3.py
@@ -204,7 +204,7 @@ def paymentCommandForLiskCore(conf, address, amount, nonce):
 	FEE = '200000'
 
 	return '\n'.join([
-		'TXC=`lisk-core transaction:create 2 0 %s --passphrase="\`echo $PASSPHRASE\`" --nonce %s --asset=\'{"data": "%s payouts", "amount":%s,"recipientAddress":"%s"}\'`' % (FEE, nonce, conf['delegateName'], amount, addressToBinary(address)),
+		'TXC=`lisk-core transaction:create 2 0 %s --passphrase="\`echo $PASSPHRASE\`" --offline --network %s --network-identifier %s --nonce %s --asset=\'{"data": "%s payouts", "amount":%s,"recipientAddress":"%s"}\'`' % (FEE, conf['network'], conf['networkIdentifier'], nonce, conf['delegateName'], amount, addressToBinary(address)),
 		'echo $TXC',
 		'lisk-core transaction:send `echo $TXC|jq .transaction -r`'
 	])


### PR DESCRIPTION
The previous version of lisk-pool3  generated some errors while trying to broadcast the transactions.

>  ›   Error: Incoming transaction fee is not sufficient to replace existing transaction

In Core v3 it is required to create the transactions offline.  This PR implements this functionality. 

It also increases the fee to allow for more content in the data field.

Fixes #3 .