### PR TITLE
Create poollogs_example.json

### DIFF
--- a/poollogs_example.json
+++ b/poollogs_example.json
@@ -1,0 +1,16 @@
+{
+    "lastPayout": {
+        "date": 1628002011,
+        "rewards": 0,
+        "producedBlocks": 0
+                  },
+    "pending": {
+                  },
+     "paid": {
+                },
+    "history": [
+                  {
+                  }
+              ]
+
+}


### PR DESCRIPTION
Creating poollogs_example file to allow people to choose a custom start date



[Rename poollogs_example.json to poollogs.json and change "date" value, according to the start time of the pool]